### PR TITLE
Move PROTOCOL and HTTP_METHOD to advanced 

### DIFF
--- a/modules/auxiliary/scanner/http/http_version.rb
+++ b/modules/auxiliary/scanner/http/http_version.rb
@@ -29,9 +29,12 @@ class Metasploit3 < Msf::Auxiliary
     })
 
     register_options([
-      OptString.new('HTTP_METHOD', [ true, 'HTTP Method to use', 'GET']),
-      OptString.new('PROTOCOL', [ false, 'Protocol to use', 'HTTP']),
-      OptString.new('TARGETURI', [ true, 'The URI to use', '/'])
+      OptString.new('TARGETURI', [true, 'The URI to use', '/'])
+    ])
+
+    register_advanced_options([
+      OptString.new('HTTP_METHOD', [true, 'HTTP Method to use', 'GET']),
+      OptString.new('PROTOCOL', [false, 'Protocol to use', 'HTTP'])
     ])
   end
 


### PR DESCRIPTION
Minor cleanup for https://github.com/rapid7/metasploit-framework/pull/5812/

In the future, you should try to branch off of `master`
